### PR TITLE
Revert "Fix Apple Vision Pro App Store Connect warning for arkit capability"

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,9 +61,6 @@
 	<array>
 		<string>arkit</string>
 	</array>
-	<key>UIRequiredDeviceCapabilities~xros</key>
-	<array>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Reverts UCSD-E4E/fishsense-mobile#32