### PR TITLE
ci: add CodeQL workflow for Swift analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,108 @@
+name: CodeQL (Swift)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '32 5 * * 1'
+
+jobs:
+  analyze-swift:
+    name: Analyze swift
+    runs-on: macos-15
+    timeout-minutes: 120
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: 🛠️ Select Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: 🐍 Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: 🦋 Setup Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        channel: stable
+
+    - name: 📦 Cache Flutter pub packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.pub-cache
+        key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pub-
+
+    - name: 📥 Get dependencies
+      run: flutter pub get
+
+    - name: 📦 Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          rust-bridge/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('rust-bridge/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: 🧱 Build Rust Bridge
+      run: |
+        python -m pip install --upgrade pip uv
+        cd rust-bridge
+        make
+
+    - name: 📱 Configure iOS App
+      run: |
+        BUNDLE_IDENTIFIER="${APP_IDENTIFIER:-com.aqua3d.fishsense}"
+        echo "PERSONAL_DEVELOPMENT_TEAM =" > ios/Flutter/DeveloperSettings.xcconfig
+        echo "FISHSENSE_BUNDLE_IDENTIFIER = ${BUNDLE_IDENTIFIER}" >> ios/Flutter/DeveloperSettings.xcconfig
+
+    - name: 📦 Cache CocoaPods
+      uses: actions/cache@v4
+      with:
+        path: ios/Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
+
+    - name: 📦 Install CocoaPods
+      run: |
+        cd ios
+        pod install
+
+    - name: 🔎 Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: swift
+        build-mode: manual
+
+    - name: 🏗️ Build iOS for CodeQL
+      run: |
+        xcodebuild build \
+          -workspace ios/Runner.xcworkspace \
+          -scheme Runner \
+          -destination 'generic/platform=iOS' \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO
+
+    - name: 🧪 Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:swift"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` to analyze Swift code with CodeQL.
- Default setup (already configured for actions, c-cpp, python, ruby) cannot scan Swift on this project because `autobuild` fails without running `flutter pub get`, `pod install`, and building the Rust bridge xcframeworks first.
- The new workflow mirrors the iOS build prep from `build.yaml`, then runs a manual-mode CodeQL analysis on the Swift sources.

## Why
The repo's "Protect Main" ruleset requires CodeQL code-scanning results before merging. Without Swift coverage, PRs that only touch Swift would never get analyzed. This closes that gap without dropping Swift from scanning entirely.

## Test plan
- [ ] CodeQL (Swift) job runs green on this PR
- [ ] Default-setup CodeQL jobs (actions/c-cpp/python/ruby) also run green
- [ ] Existing `build.yaml` still passes